### PR TITLE
Fix profile photo operations

### DIFF
--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -292,10 +292,10 @@ class AuthService {
   }
 
   // Update profile photo
-  Future<void> updateProfilePhoto(String userId, String photoUrl) async {
+  Future<void> updateProfilePhoto(String userId, String? photoUrl) async {
     try {
       await _firestore.collection('users').doc(userId).update({
-        'profilePhoto': photoUrl,
+        'photoUrl': photoUrl,
         'updatedAt': FieldValue.serverTimestamp(),
       });
       

--- a/lib/providers/user_provider.dart
+++ b/lib/providers/user_provider.dart
@@ -46,12 +46,24 @@ class UserProfileNotifier extends AsyncNotifier<UserModel?> {
   }
 
   // Update profile photo
-  Future<void> updateProfilePhoto(String photoUrl) async {
+  Future<void> updateProfilePhoto(String? photoUrl) async {
     final currentUser = state.valueOrNull;
     if (currentUser == null) return;
     try {
       final authService = ref.read(authServiceProvider);
       await authService.updateProfilePhoto(currentUser.id, photoUrl);
+      await refreshUserProfile();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> removeProfilePhoto() async {
+    final currentUser = state.valueOrNull;
+    if (currentUser == null) return;
+    try {
+      final authService = ref.read(authServiceProvider);
+      await authService.updateProfilePhoto(currentUser.id, null);
       await refreshUserProfile();
     } catch (e) {
       rethrow;


### PR DESCRIPTION
## Summary
- allow nullable photo url in auth service and use `photoUrl` field
- update user provider for nullable photo url and add remove function
- use `StorageService` for picking/uploading/deleting profile photos
- add option to remove profile photo

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e141915083238175a9416935eebd