### PR TITLE
Add birth date validation

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -133,6 +133,8 @@
         "validation_last_name_required": "Please enter your last name",
         "validation_email_required": "Please enter your email address",
         "validation_email_invalid": "Please enter a valid email address",
+        "validation_birth_date_required": "Please select your birth date",
+        "validation_birth_date_invalid": "Please enter a valid birth date",
         "verify_email": "Verify Email",
         "verification_title": "Email Verification",
         "verification_description": "We've sent a verification code to {email}. Please enter the 6-digit code below.",

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -128,6 +128,8 @@
         "validation_last_name_required": "Lütfen soyadınızı girin",
         "validation_email_required": "Lütfen e-posta adresinizi girin",
         "validation_email_invalid": "Lütfen geçerli bir e-posta adresi girin",
+        "validation_birth_date_required": "Lütfen doğum tarihinizi seçin",
+        "validation_birth_date_invalid": "Geçersiz doğum tarihi",
         "verify_email": "E-posta Doğrula",
         "verification_title": "E-posta Doğrulama",
         "verification_description": "{email} adresine doğrulama kodu gönderdik. Lütfen aşağıya 6 haneli kodu girin.",

--- a/assets/translations/tr_clean.json
+++ b/assets/translations/tr_clean.json
@@ -123,6 +123,8 @@
         "validation_last_name_required": "Lütfen soyadınızı giriniz",
         "validation_email_required": "Lütfen email adresinizi giriniz",
         "validation_email_invalid": "Geçerli bir email adresi giriniz",
+        "validation_birth_date_required": "Lütfen doğum tarihinizi seçiniz",
+        "validation_birth_date_invalid": "Geçersiz doğum tarihi",
         "verify_email": "E-posta Doğrulama",
         "verification_title": "E-posta Doğrulama",
         "verification_description": "{email} adresine bir doğrulama kodu gönderdik. Lütfen 6 haneli kodu aşağıya giriniz.",

--- a/lib/core/utils/validation_utils.dart
+++ b/lib/core/utils/validation_utils.dart
@@ -71,4 +71,18 @@ class ValidationUtils {
     }
     return null;
   }
+
+  /// Validates a [DateTime] value for a birth date field.
+  ///
+  /// Returns a translation key if the value is null or represents a date in
+  /// the future, otherwise `null`.
+  static String? validateBirthDate(BuildContext context, DateTime? value) {
+    if (value == null) {
+      return T(context, 'auth.validation_birth_date_required');
+    }
+    if (value.isAfter(DateTime.now())) {
+      return T(context, 'auth.validation_birth_date_invalid');
+    }
+    return null;
+  }
 }

--- a/lib/features/auth/screens/register_screen.dart
+++ b/lib/features/auth/screens/register_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hand_speak/core/widgets/auth_text_field.dart';
 import 'package:hand_speak/core/widgets/auth_button.dart';
 import 'package:hand_speak/core/utils/translation_helper.dart' show T;
+import 'package:hand_speak/core/utils/validation_utils.dart';
 import 'package:hand_speak/providers/auth_provider.dart';
 import 'package:hand_speak/providers/user_provider.dart';
 
@@ -24,6 +25,7 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen>
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _confirmPasswordController = TextEditingController();
+  DateTime? _birthDate;
   bool _isLoading = false;
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
@@ -96,6 +98,21 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen>
 
   Future<void> _handleRegister() async {
     if (!_formKey.currentState!.validate()) return;
+
+    final birthDateError =
+        ValidationUtils.validateBirthDate(context, _birthDate);
+    if (birthDateError != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(birthDateError),
+          backgroundColor: Colors.red,
+          behavior: SnackBarBehavior.floating,
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        ),
+      );
+      return;
+    }
 
     setState(() => _isLoading = true);
 


### PR DESCRIPTION
## Summary
- add date of birth validation helper
- localize new validation strings
- ensure RegisterScreen checks birth date before registering

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684705ece098832384a218012fc0d147