### PR TITLE
Remove content menu section

### DIFF
--- a/lib/features/home/widgets/profile_tab.dart
+++ b/lib/features/home/widgets/profile_tab.dart
@@ -700,18 +700,6 @@ class _UltraModernProfileTabState extends ConsumerState<UltraModernProfileTab>
         ],
       },
       {
-        'title': 'İçerik',
-        'items': [
-          {
-            'icon': Icons.videocam_outlined,
-            'title': T(context, 'profile.my_videos'),
-            'subtitle': 'Kaydettiğiniz videolar',
-            'color': const Color(0xFF10B981),
-            'onTap': () => context.push('/videos'),
-          },
-        ],
-      },
-      {
         'title': 'Destek',
         'items': [
           {


### PR DESCRIPTION
## Summary
- remove the `İçerik` menu section from profile tab

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847079c615c83239129922db41ffcf3