### PR TITLE
Add select_video translations

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -379,5 +379,6 @@
     },
     "myVideosTitle": "My Videos",
     "myVideosNoVideos": "You don't have any videos yet",
-    "myVideosRecordNew": "Record New Video"
+    "myVideosRecordNew": "Record New Video",
+    "select_video": "Select Video"
 }

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -373,5 +373,6 @@
     },
     "myVideosTitle": "Videolarım",
     "myVideosNoVideos": "Henüz hiç videonuz yok",
-    "myVideosRecordNew": "Yeni Video Kaydet"
+    "myVideosRecordNew": "Yeni Video Kaydet",
+    "select_video": "Video Seç"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -330,5 +330,9 @@
   },
   "cameraPreparing": "Camera is preparing...",
   "recordingInProgress": "Recording...",
-  "effects": "Effects"
+  "effects": "Effects",
+  "selectVideo": "Select Video",
+  "@selectVideo": {
+    "description": "Title when selecting a video"
+  }
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -369,5 +369,9 @@
   },
   "cameraPreparing": "Kamera hazırlanıyor...",
   "recordingInProgress": "Kayıt yapılıyor...",
-  "effects": "Efektler"
+  "effects": "Efektler",
+  "selectVideo": "Video Seç",
+  "@selectVideo": {
+    "description": "Video galerisinde seçim modu başlığı"
+  }
 }


### PR DESCRIPTION
## Summary
- add `select_video` text for English and Turkish translations
- mirror translations in ARB localization files

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684707a836188323affb5379ad4c4082