### PR TITLE
Remove unused video translations

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -376,8 +376,6 @@
     "numbers": {
         "title": "Numbers",
         "description": "Learn numbers from 0 to 10"
-    },
-    "myVideosTitle": "My Videos",
-    "myVideosNoVideos": "You don't have any videos yet",
-    "myVideosRecordNew": "Record New Video"
+    }
+    
 }

--- a/assets/translations/tr.json
+++ b/assets/translations/tr.json
@@ -370,8 +370,6 @@
     "numbers": {
         "title": "Sayılar",
         "description": "0'dan 10'a kadar sayıları öğrenin"
-    },
-    "myVideosTitle": "Videolarım",
-    "myVideosNoVideos": "Henüz hiç videonuz yok",
-    "myVideosRecordNew": "Yeni Video Kaydet"
+    }
+
 }

--- a/lib/features/home/widgets/profile_tab.dart
+++ b/lib/features/home/widgets/profile_tab.dart
@@ -700,18 +700,6 @@ class _UltraModernProfileTabState extends ConsumerState<UltraModernProfileTab>
         ],
       },
       {
-        'title': 'İçerik',
-        'items': [
-          {
-            'icon': Icons.videocam_outlined,
-            'title': T(context, 'profile.my_videos'),
-            'subtitle': 'Kaydettiğiniz videolar',
-            'color': const Color(0xFF10B981),
-            'onTap': () => context.push('/videos'),
-          },
-        ],
-      },
-      {
         'title': 'Destek',
         'items': [
           {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -236,18 +236,6 @@
   "@profileClose": {
     "description": "Dialog close button"
   },
-  "myVideosTitle": "My Videos",
-  "@myVideosTitle": {
-    "description": "Title for my videos screen"
-  },
-  "myVideosNoVideos": "You don't have any videos yet",
-  "@myVideosNoVideos": {
-    "description": "Text shown when user has no videos"
-  },
-  "myVideosRecordNew": "Record New Video",
-  "@myVideosRecordNew": {
-    "description": "Text for record new video button"
-  },
   "myVideosPlay": "Play",
   "@myVideosPlay": {
     "description": "Text for play button"
@@ -263,10 +251,6 @@
   "myVideosProcessing": "Processing translation...",
   "@myVideosProcessing": {
     "description": "Text shown when video is being processed for translation"
-  },
-  "profileMyVideos": "My Videos",
-  "@profileMyVideos": {
-    "description": "Text for my videos menu item in profile"
   },
   "homeLearn": "Learn",
   "@homeLearn": {

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -272,7 +272,6 @@
   "profileSettings": "Ayarlar",
   "profileHelp": "Yardım",
   "profileAbout": "Hakkında",
-  "profileMyVideos": "Videolarım",
   "profileLogout": "Çıkış Yap",
   "app_name": "Hand Speak",
   "auth.login_title": "Giriş Yap",
@@ -324,7 +323,6 @@
   "profile.settings": "Ayarlar",
   "profile.help": "Yardım",
   "profile.about": "Hakkında",
-  "profile.my_videos": "Videolarım",
   "profile.logout": "Çıkış Yap",
   "common.cancel": "İptal",
   "general.settings": "Ayarlar",
@@ -339,18 +337,6 @@
   "settings.enable_audio_description": "Video ile birlikte ses de kaydet",
   "settings.reset_to_default": "Varsayılana Döndür",
   "settings.save": "Kaydet",
-  "myVideosTitle": "Videolarım",
-  "@myVideosTitle": {
-    "description": "Videolarım ekranı başlığı"
-  },
-  "myVideosNoVideos": "Henüz hiç videonuz yok",
-  "@myVideosNoVideos": {
-    "description": "Kullanıcının hiç videosu olmadığında gösterilen metin"
-  },
-  "myVideosRecordNew": "Yeni Video Kaydet",
-  "@myVideosRecordNew": {
-    "description": "Yeni video kaydet düğmesi için metin"
-  },
   "myVideosPlay": "Oynat",
   "@myVideosPlay": {
     "description": "Oynat düğmesi için metin"


### PR DESCRIPTION
## Summary
- delete obsolete keys from translation files
- drop My Videos menu item from profile tab

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684707a1f558832382e20b40b1137283